### PR TITLE
Disable spawnprotection on physgun activities

### DIFF
--- a/lua/autorun/server/sv_spawn_protection.lua
+++ b/lua/autorun/server/sv_spawn_protection.lua
@@ -252,16 +252,10 @@ hook.Add( "OnPhysgunPickup", "CFCremoveSpawnProtectionOnPhysgunPickup", function
     instantRemoveSpawnProtection( ply, "You've picked up a prop and lost spawn protection." )
 end )
 
-hook.Add( "OnPhysgunReload", "CFCremoveSpawnProtectionOnPhysgunReload", function( ply )
+hook.Add( "CanPlayerUnfreeze", "CFCremoveSpawnProtectionOnUnfreeze", function( ply )
     if not playerHasSpawnProtection( ply ) then return end
 
     instantRemoveSpawnProtection( ply, "You unfroze props and lost spawn protection." )
-end )
-
-hook.Add( "OnPhysgunFreeze", "CFCremoveSpawnProtectionOnPhysgunFreeze", function( ply )
-    if not playerHasSpawnProtection( ply ) then return end
-
-    instantRemoveSpawnProtection( ply, "You unfroze a prop and lost spawn protection." )
 end )
 
 -- Enable spawn protection when spawning in PvP

--- a/lua/autorun/server/sv_spawn_protection.lua
+++ b/lua/autorun/server/sv_spawn_protection.lua
@@ -252,12 +252,6 @@ hook.Add( "OnPhysgunPickup", "CFCremoveSpawnProtectionOnPhysgunPickup", function
     instantRemoveSpawnProtection( ply, "You've picked up a prop and lost spawn protection." )
 end )
 
-hook.Add( "CanPlayerUnfreeze", "CFCremoveSpawnProtectionOnUnfreeze", function( ply )
-    if not playerHasSpawnProtection( ply ) then return end
-
-    instantRemoveSpawnProtection( ply, "You unfroze props and lost spawn protection." )
-end )
-
 -- Enable spawn protection when spawning in PvP
 hook.Add( "PlayerSpawn", "CFCsetSpawnProtection", setSpawnProtectionForPvpSpawn )
 

--- a/lua/autorun/server/sv_spawn_protection.lua
+++ b/lua/autorun/server/sv_spawn_protection.lua
@@ -245,6 +245,25 @@ hook.Add( "PlayerEnteredVehicle", "CFCremoveSpawnProtectionOnEnterVehicle", func
     instantRemoveSpawnProtection( ply, "You've entered a vehicle and lost spawn protection." )
 end )
 
+-- Physgun activity
+hook.Add( "OnPhysgunPickup", "CFCremoveSpawnProtectionOnPhysgunPickup", function( ply )
+    if not playerHasSpawnProtection( ply ) then return end
+
+    instantRemoveSpawnProtection( ply, "You've picked up a prop and lost spawn protection." )
+end )
+
+hook.Add( "OnPhysgunReload", "CFCremoveSpawnProtectionOnPhysgunReload", function( ply )
+    if not playerHasSpawnProtection( ply ) then return end
+
+    instantRemoveSpawnProtection( ply, "You unfroze props and lost spawn protection." )
+end )
+
+hook.Add( "OnPhysgunFreeze", "CFCremoveSpawnProtectionOnPhysgunFreeze", function( ply )
+    if not playerHasSpawnProtection( ply ) then return end
+
+    instantRemoveSpawnProtection( ply, "You unfroze a prop and lost spawn protection." )
+end )
+
 -- Enable spawn protection when spawning in PvP
 hook.Add( "PlayerSpawn", "CFCsetSpawnProtection", setSpawnProtectionForPvpSpawn )
 


### PR DESCRIPTION
Player can currently still use their physgun to propthrow, propfly and such when they're under spawn protection. This should not be possible as it allows for an unfair advantage.