### PR TITLE
Fix spawn protection not applying

### DIFF
--- a/lua/autorun/server/sv_spawn_protection.lua
+++ b/lua/autorun/server/sv_spawn_protection.lua
@@ -159,11 +159,9 @@ local function setSpawnProtectionForPvpSpawn( ply )
 
     if playerSpawnedAtEnemySpawnPoint( ply ) then return end
 
-    timer.Simple( 0, function()
-        setSpawnProtection( ply )
-        setPlayerTransparent( ply )
-        createDecayTimer( ply )
-    end )
+    setSpawnProtection( ply )
+    setPlayerTransparent( ply )
+    createDecayTimer( ply )
 end
 
 -- Instantly removes spawn protection and removes timers and alpha level.
@@ -236,8 +234,8 @@ hook.Add( "OnPhysgunPickup", "CFCremoveSpawnProtectionOnPhysgunPickup", function
     instantRemoveSpawnProtection( ply, "You've picked up a prop and lost spawn protection." )
 end )
 
--- Enable spawn protection when spawning in PvP
-hook.Add( "PlayerSpawn", "CFCsetSpawnProtection", setSpawnProtectionForPvpSpawn )
+-- PlayerSetModel runs after PlayerLoadout, so we can use it to set spawn protection
+hook.Add( "PlayerSetModel", "CFCsetSpawnProtection", setSpawnProtectionForPvpSpawn, HOOK_HIGH )
 
 -- Trigger spawn protection removal on player move
 hook.Add( "KeyPress", "CFCspawnProtectionMoveCheck", spawnProtectionMoveCheck )

--- a/lua/autorun/server/sv_spawn_protection.lua
+++ b/lua/autorun/server/sv_spawn_protection.lua
@@ -135,7 +135,7 @@ local function playerSpawnedAtEnemySpawnPoint( ply )
 end
 
 local function playerIsInPvp( ply )
-    return ply:IsInPvp()
+    return ply.IsInPvp and ply:IsInPvp() or true
 end
 
 local function playerHasSpawnProtection( ply )
@@ -237,7 +237,7 @@ hook.Add( "OnPhysgunPickup", "CFCremoveSpawnProtectionOnPhysgunPickup", function
 end )
 
 -- Enable spawn protection when spawning in PvP
-hook.Add( "PlayerLoadout", "CFCsetSpawnProtection", setSpawnProtectionForPvpSpawn )
+hook.Add( "PlayerSpawn", "CFCsetSpawnProtection", setSpawnProtectionForPvpSpawn )
 
 -- Trigger spawn protection removal on player move
 hook.Add( "KeyPress", "CFCspawnProtectionMoveCheck", spawnProtectionMoveCheck )


### PR DESCRIPTION
The addon used the hook `PlayerLoadout` but that hook is highly likely to be early returned from to a point where it's simply not usable, so instead we should use `PlayerSpawn`